### PR TITLE
fix(README.md): added info for pageRangeText translation

### DIFF
--- a/projects/quang/components/paginator/README.md
+++ b/projects/quang/components/paginator/README.md
@@ -17,7 +17,7 @@ The `QuangPaginatorComponent` provides controls for navigating through pages of 
 - `showTotalElementsCount`: `boolean` — Show/hide total items count. Default: `true`.
 - `totalItemsText`: `string` — Translation key for total items label. Default: `'quangPaginator.totalItems'`.
 - `sizeText`: `string` — Translation key for size label. Default: `'quangPaginator.size'`.
-- `pageRangeText`: `string` — Translation key for page range label. Default: `'quangPaginator.pageRange'`.
+- `pageRangeText`: `string` — Translation key for page range label. Default: `'quangPaginator.pageRange'`. If the translation is overwritten, it should contain `{{page}}` and `{{amountPages}}` placeholders to display the correct numeric values.
 - `componentId`, `componentTabIndex`, `componentClass`: Standard component inputs.
 
 ## Outputs


### PR DESCRIPTION
Se il valore della traduzione viene sovrascritto dall'applicativo, alla traduzione quangPaginator.pageRange bisogna passare i valori della page e del total: aggiunta questa informazione del README.md come richiesto